### PR TITLE
Resolve issues with Pubmote connection while using VESC Express station mode

### DIFF
--- a/float_accessories/README.md
+++ b/float_accessories/README.md
@@ -22,6 +22,6 @@ Now with BMS and Pubmote (beta)
 
 <H3>BUILD INFO</H3>
 
-Version 2.2
+Version 2.5
 
 Source code can be found here:  <a href='https://github.com/relys/vesc%5Fpkg'>https://github.com/relys/vesc_pkg</a>

--- a/float_accessories/lib/can.lisp
+++ b/float_accessories/lib/can.lisp
@@ -16,7 +16,6 @@
 (def fet-temp-filtered 0)
 (def motor-temp-filtered 0)
 (def odometer -1)
-(def odometer-init -1)
 (def battery-percent-remaining 0.0)
 (def can-id -1)
 (def bms-can-id -1)
@@ -191,14 +190,12 @@
                                 (setq tot-current (/ (to-float (bufget-i16 data 28)) 10))
                                 (setq duty-cycle-now (/ (to-float (- (bufget-u8 data 32) 128)) 100))
                                 (if (and (>= mode 2) (>= (buflen data) 39)) {
-                                    ;(def distance-abs-t (bufget-f32-auto data 34))
+                                    (setq distance-abs (bufget-f32 data 34))
                                     (setq fet-temp-filtered (/ (bufget-u8 data 38) 2.0))
                                     (setq motor-temp-filtered (/ (bufget-u8 data 39) 2.0))
                                 })
                                 (if (and (>= mode 3) (>= (buflen data) 52)) {
                                     (setq odometer (bufget-u32 data 41))
-                                    (if (= odometer-init -1) (setq odometer-init odometer))
-                                    (setq distance-abs (- odometer odometer-init))
                                     (if (not refloat-battery-percent) (setq battery-percent-remaining (/ (to-float (bufget-u8 data 53)) 2)))
                                 })
                             })

--- a/float_accessories/lib/pubmote.lisp
+++ b/float_accessories/lib/pubmote.lisp
@@ -8,13 +8,13 @@
 (def pubmote-pairing-timer 31)
 (def uni-mac '(255 255 255 255 255 255)) ; Universal mac (all devices)
 (def channel-locked 0)
+
 (defunret init-pubmote () {
     ; Escape without wifi
     (if (not wifi-enabled-on-boot){
         (send-msg "WiFi was disabled on boot. Please enable and reboot to use Pubmote.")
         (return false)
     })
-    ;(wifi-set-chan (wifi-get-chan))
     (setq esp-now-remote-mac (append (unpack-uint32-to-bytes (get-config 'esp-now-remote-mac-a)) (take (unpack-uint32-to-bytes (get-config 'esp-now-remote-mac-b)) 2)))
     ; Read as bytes, convert to i so we can compare lists
     (loopfor i 0 (< i(length esp-now-remote-mac)) (+ i 1) {
@@ -40,7 +40,8 @@
             (setq pubmote-pairing-timer (systime))
             (setq pairing-state 1)
         })
-        ((= pairing -1) { ;paring accepted
+        ; Pairing accepted
+        ((= pairing -1) {
             (set-config 'esp-now-remote-mac-a (pack-bytes-to-uint32 (take esp-now-remote-mac 4)))
             (set-config 'esp-now-remote-mac-b (pack-bytes-to-uint32 (append (drop esp-now-remote-mac 4) '(0 0))))
             (write-val-eeprom 'esp-now-remote-mac-a (get-config 'esp-now-remote-mac-a))
@@ -54,7 +55,8 @@
             (free tmpbuf)
             (setq pairing-state 0)
         })
-        ((= pairing -2) { ;paring rejected
+        ; Pairing rejected
+        ((= pairing -2) {
             (set-config 'esp-now-remote-mac-a -1)
             (write-val-eeprom 'esp-now-remote-mac-a (get-config 'esp-now-remote-mac-a) -1)
             (write-val-eeprom 'crc (config-crc))
@@ -91,12 +93,16 @@
 })
 
 (defun should-lock-channel () {
-    ; Disconnected and not already flagged
+    ; Channel is not locked
+    ; Station mode
+    ; Wifi is not connected
     (and (eq channel-locked 0) (is-station-mode) (not (is-wifi-connected)))
 })
 
 (defun should-unlock-channel (last-activity-time) {
-    ; Disconnected and already flagged and more than 5 seconds since last pubmote rx
+    ; Channel is locked,
+    ; Remote is disconnected
+    ; More than 10 seconds since last Pubmote rx
     (and (> channel-locked 0) (is-station-mode) (> (secs-since last-activity-time) 10))
 })
 
@@ -119,7 +125,7 @@
                 })
                 (if (and (> (secs-since pubmote-pairing-timer) 30 ) (>= pairing-state 1)) {
                     (pair-pubmote -2)
-                }) ;timeout pairing process after 30 seconds
+                }) ; Timeout pairing process after 30 seconds
                 (if (= pairing-state 1) {
                     (if (should-lock-channel) {
                         (lock-channel "ESP-NOW packet received")
@@ -129,8 +135,8 @@
                     (looprange i 0 (buflen pairing-data) {
                         (bufset-u8 pairing-data i (ix local-mac i))
                     })
-                    ;(bufset-u8 data 0 69)
-                    ;(print "sending pairing info")
+                    ; (bufset-u8 data 0 69)
+                    ; (print "sending pairing info")
                     (esp-now-send uni-mac pairing-data)
                     (free pairing-data)
                 })
@@ -180,14 +186,14 @@
         (if (and (= pairing-state 0) (eq esp-now-remote-mac src) (= (buflen data) 16) (= (bufget-i32 data 0 'little-endian) (get-config 'esp-now-secret-code))) {
             (atomic {
                 (setq pubmote-last-activity-time (systime))
-                ;(print (list "Received" src des data rssi))
+                ; (print (list "Received" src des data rssi))
                 (var jsy (bufget-f32 data 4 'little-endian))
                 (var jsx (bufget-f32 data 8 'little-endian))
                 (var bt-c (bufget-u8 data 12))
                 (var bt-z (bufget-u8 data 13))
                 (var is-rev (bufget-u8 data 14))
-                ;(print (list jsy jsx bt-c bt-z is-rev))
-                ;(rcode-run-noret (get-config 'can-id) `(set-remote-state ,jsy ,jsx ,bt-c ,bt-z ,is-rev))
+                ; (print (list jsy jsx bt-c bt-z is-rev))
+                ; (rcode-run-noret (get-config 'can-id) `(set-remote-state ,jsy ,jsx ,bt-c ,bt-z ,is-rev))
                 (if (>= (get-config 'can-id) 0) {
                     (can-cmd (get-config 'can-id) (str-replace (to-str(list jsy jsx bt-c bt-z is-rev)) "(" "(set-remote-state "))
                 })

--- a/float_accessories/lib/pubmote.lisp
+++ b/float_accessories/lib/pubmote.lisp
@@ -89,6 +89,7 @@
     (print (str-merge "Channel switching enabled. Reason: " reason))
     (setq channel-locked 0)
     (wifi-auto-reconnect true)
+    (wifi-connect (conf-get `wifi-sta-ssid) (conf-get `wifi-sta-key))
 })
 
 (defun is-station-mode () {

--- a/float_accessories/lib/pubmote.lisp
+++ b/float_accessories/lib/pubmote.lisp
@@ -11,15 +11,18 @@
 
 (defunret init-pubmote () {
     ; Escape without wifi
-    (if (not wifi-enabled-on-boot){
+    (if (not wifi-enabled-on-boot) {
         (send-msg "WiFi was disabled on boot. Please enable and reboot to use Pubmote.")
         (return false)
     })
+
     (setq esp-now-remote-mac (append (unpack-uint32-to-bytes (get-config 'esp-now-remote-mac-a)) (take (unpack-uint32-to-bytes (get-config 'esp-now-remote-mac-b)) 2)))
+
     ; Read as bytes, convert to i so we can compare lists
-    (loopfor i 0 (< i(length esp-now-remote-mac)) (+ i 1) {
+    (loopfor i 0 (< i (length esp-now-remote-mac)) (+ i 1) {
         (setix esp-now-remote-mac i (to-i (ix esp-now-remote-mac i)))
     })
+
     (esp-now-start)
     (esp-now-del-peer esp-now-remote-mac)
     (esp-now-add-peer esp-now-remote-mac)
@@ -34,12 +37,14 @@
         (send-msg "WiFi is disabled. Please enable and reboot.")
         (return false)
     })
+
     (cond
         ((>= pairing 0) {
             (set-config 'esp-now-secret-code (to-i32 pairing))
             (setq pubmote-pairing-timer (systime))
             (setq pairing-state 1)
         })
+
         ; Pairing accepted
         ((= pairing -1) {
             (set-config 'esp-now-remote-mac-a (pack-bytes-to-uint32 (take esp-now-remote-mac 4)))
@@ -55,6 +60,7 @@
             (free tmpbuf)
             (setq pairing-state 0)
         })
+
         ; Pairing rejected
         ((= pairing -2) {
             (set-config 'esp-now-remote-mac-a -1)
@@ -68,6 +74,7 @@
             (setq pairing-state 0)
         })
     )
+
     (return true)
 })
 
@@ -107,39 +114,49 @@
 })
 
 (defun pubmote-loop () {
-    (if (init-pubmote){
+    (if (init-pubmote) {
         (setq pubmote-loop-delay (get-config 'pubmote-loop-delay))
         (var next-run-time (secs-since 0))
         (var loop-start-time 0)
         (var loop-end-time 0)
         (var pubmote-loop-delay-sec (/ 1.0 pubmote-loop-delay))
         (var data (bufcreate 32))
+
         (loopwhile t {
             (if (get-config 'pubmote-enabled) {
                 (if (should-unlock-channel pubmote-last-activity-time) {
                     (unlock-channel "Inactivity timeout")
                 })
+
                 (setq loop-start-time  (secs-since 0))
+
                 (if pubmote-exit-flag {
                     (break)
                 })
+
+                ; Timeout pairing process after 30 seconds
                 (if (and (> (secs-since pubmote-pairing-timer) 30 ) (>= pairing-state 1)) {
                     (pair-pubmote -2)
-                }) ; Timeout pairing process after 30 seconds
+                })
+
                 (if (= pairing-state 1) {
                     (if (should-lock-channel) {
                         (lock-channel "ESP-NOW packet received")
                     })
+
                     (var pairing-data (bufcreate 6))
                     (var local-mac (get-mac-addr))
+
                     (looprange i 0 (buflen pairing-data) {
                         (bufset-u8 pairing-data i (ix local-mac i))
                     })
+
                     ; (bufset-u8 data 0 69)
                     ; (print "sending pairing info")
                     (esp-now-send uni-mac pairing-data)
                     (free pairing-data)
                 })
+
                 (if (and (= pairing-state 0) (!= (get-config 'esp-now-remote-mac-a) -1) (>= (get-config 'can-id) 0)) {
                     (bufset-u8 data 0 69) ; Mode
                     (bufset-u8 data 1 fault-code)
@@ -160,9 +177,9 @@
                     (bufset-i32 data 28 (get-config 'esp-now-secret-code))
                     (esp-now-send esp-now-remote-mac data)
                 })
+
                 (setq loop-end-time (secs-since 0))
                 (var actual-loop-time (- loop-end-time loop-start-time))
-
                 (var time-to-wait (- next-run-time (secs-since 0)))
 
                 (if (> time-to-wait 0) {
@@ -170,9 +187,11 @@
                 }{
                     (setq next-run-time (secs-since 0))
                 })
+
                 (setq next-run-time (+ next-run-time pubmote-loop-delay-sec))
             })
         })
+
         (free data)
         (setq pubmote-exit-flag nil)
     })
@@ -183,6 +202,7 @@
         (if (should-lock-channel) {
             (lock-channel "ESP-NOW packet received")
         })
+
         (if (and (= pairing-state 0) (eq esp-now-remote-mac src) (= (buflen data) 16) (= (bufget-i32 data 0 'little-endian) (get-config 'esp-now-secret-code))) {
             (atomic {
                 (setq pubmote-last-activity-time (systime))
@@ -194,6 +214,7 @@
                 (var is-rev (bufget-u8 data 14))
                 ; (print (list jsy jsx bt-c bt-z is-rev))
                 ; (rcode-run-noret (get-config 'can-id) `(set-remote-state ,jsy ,jsx ,bt-c ,bt-z ,is-rev))
+                
                 (if (>= (get-config 'can-id) 0) {
                     (can-cmd (get-config 'can-id) (str-replace (to-str(list jsy jsx bt-c bt-z is-rev)) "(" "(set-remote-state "))
                 })

--- a/float_accessories/lib/pubmote.lisp
+++ b/float_accessories/lib/pubmote.lisp
@@ -8,12 +8,17 @@
 (def pubmote-pairing-timer 31)
 (def uni-mac '(255 255 255 255 255 255)) ; Universal mac (all devices)
 (defunret init-pubmote () {
+    ; Escape without wifi
     (if (not wifi-enabled-on-boot){
-        (send-msg "WiFi was disabled on boot. Please enable and reboot to use pubmote.")
+        (send-msg "WiFi was disabled on boot. Please enable and reboot to use Pubmote.")
         (return false)
     })
-    ;(wifi-set-chan (wifi-get-chan))
-    (setq esp-now-remote-mac (append (unpack-uint32-to-bytes (get-config 'esp-now-remote-mac-a)) (take (unpack-uint32-to-bytes (get-config 'esp-now-remote-mac-b)) 2)));
+    ; Station mode and connecting should disable auto reconnect to stop channel hopping
+    (if (and (eq (conf-get 'wifi-mode) 1) (not-eq (wifi-status) 'connected)) {
+        (wifi-auto-reconnect false) ; don't try to auto-reconnect if wifi is in station mode
+        (wifi-disconnect)
+    })
+    (setq esp-now-remote-mac (append (unpack-uint32-to-bytes (get-config 'esp-now-remote-mac-a)) (take (unpack-uint32-to-bytes (get-config 'esp-now-remote-mac-b)) 2)))
     ; Read as bytes, convert to i so we can compare lists
     (loopfor i 0 (< i(length esp-now-remote-mac)) (+ i 1) {
         (setix esp-now-remote-mac i (to-i (ix esp-now-remote-mac i)))
@@ -28,7 +33,7 @@
 
 ;todo more robust pairing process. Needs to keep sending packets as a missed packet can lead to invalid state machine.
 (defunret pair-pubmote (pairing) {
-    (if (= (conf-get 'wifi-mode) 0) {
+    (if (eq (conf-get 'wifi-mode) 0) {
         (send-msg "WiFi is disabled. Please enable and reboot.")
         (return false)
     })
@@ -38,7 +43,7 @@
             (setq pubmote-pairing-timer (systime))
             (setq pairing-state 1)
         })
-        ((= pairing -1) { ;paring accepted
+        ((eq pairing -1) { ;pairing accepted
             (set-config 'esp-now-remote-mac-a (pack-bytes-to-uint32 (take esp-now-remote-mac 4)))
             (set-config 'esp-now-remote-mac-b (pack-bytes-to-uint32 (append (drop esp-now-remote-mac 4) '(0 0))))
             (write-val-eeprom 'esp-now-remote-mac-a (get-config 'esp-now-remote-mac-a))
@@ -52,7 +57,7 @@
             (free tmpbuf)
             (setq pairing-state 0)
         })
-        ((= pairing -2) { ;paring rejected
+        ((eq pairing -2) { ;paring rejected
             (set-config 'esp-now-remote-mac-a -1)
             (write-val-eeprom 'esp-now-remote-mac-a (get-config 'esp-now-remote-mac-a) -1)
             (write-val-eeprom 'crc (config-crc))
@@ -75,17 +80,31 @@
         (var loop-end-time 0)
         (var pubmote-loop-delay-sec (/ 1.0 pubmote-loop-delay))
         (var data (bufcreate 32))
+        (var channel-locked 0)
         (loopwhile t {
-            (if (get-config 'pubmote-enabled){
-                (setq loop-start-time  (secs-since 0))
+            (if (get-config 'pubmote-enabled) {
+                ;; Station mode and disconnected and not already flagged
+                (if (and (eq (conf-get 'wifi-mode) 1) (not-eq (wifi-status) 'connected) (not channel-locked)) {
+                    (setq channel-locked 1)
+                    (wifi-auto-reconnect false)
+                    (wifi-disconnect)
+                    (esp-now-start)
+                })
+                ;; Station mode and disconnected and already flagged and more than 5 seconds since last pubmote rx
+                (if (and (eq (conf-get 'wifi-mode) 1) channel-locked (> (secs-since pubmote-last-activity-time) 5)) {
+                    (setq channel-locked 0)
+                    (wifi-auto-reconnect true)
+                    (wifi-connect)
+                    (esp-now-start)
+                })
+                (setq loop-start-time (secs-since 0))
                 (if pubmote-exit-flag {
                     (break)
                 })
                 (if (and (> (secs-since pubmote-pairing-timer) 30 ) (>= pairing-state 1)) {
                     (pair-pubmote -2)
                 }) ;timeout pairing process after 30 seconds
-                (if (= pairing-state 1) {
-
+                (if (eq pairing-state 1) {
                     (var pairing-data (bufcreate 6))
                     (var local-mac (get-mac-addr))
                     (looprange i 0 (buflen pairing-data) {
@@ -96,7 +115,7 @@
                     (esp-now-send uni-mac pairing-data)
                     (free pairing-data)
                 })
-                (if (and (= pairing-state 0) (!= (get-config 'esp-now-remote-mac-a) -1) (>= (get-config 'can-id) 0)) {
+                (if (and (eq pairing-state 0) (!= (get-config 'esp-now-remote-mac-a) -1) (>= (get-config 'can-id) 0)) {
                     (bufset-u8 data 0 69) ; Mode
                     (bufset-u8 data 1 fault-code)
                     (bufset-i16 data 2 (floor (* pitch-angle 10)))
@@ -136,7 +155,7 @@
 
 (defun pubmote-rx (src des data rssi) {
     (if (get-config 'pubmote-enabled){
-        (if (and (= pairing-state 0) (eq esp-now-remote-mac src) (= (buflen data) 16) (= (bufget-i32 data 0 'little-endian) (get-config 'esp-now-secret-code))) {
+        (if (and (eq pairing-state 0) (eq esp-now-remote-mac src) (eq (buflen data) 16) (eq (bufget-i32 data 0 'little-endian) (get-config 'esp-now-secret-code))) {
             (atomic {
                 (setq pubmote-last-activity-time (systime))
                 ;(print (list "Received" src des data rssi))
@@ -152,7 +171,7 @@
                 })
             })
         }{
-            (if (= pairing-state 1) {
+            (if (eq pairing-state 1) {
                 (setq esp-now-remote-mac src)
                 (esp-now-add-peer esp-now-remote-mac)
                 (var tmpbuf (bufcreate 4))

--- a/float_accessories/lib/settings.lisp
+++ b/float_accessories/lib/settings.lisp
@@ -93,7 +93,6 @@
 (def pubmote-context-id -1)
 (def pubmote-exit-flag nil)
 (def pubmote-last-activity-time (systime))
-(def wifi-current-channel -1)
 (def led-context-id -1)
 (def led-exit-flag nil)
 (def led-last-activity-time (systime))
@@ -108,61 +107,79 @@
     (setq led-brightness-highbeam (to-float in-led-brightness-highbeam))
     (setq led-brightness-idle (to-float in-led-brightness-idle))
     (setq led-brightness-status (to-float in-led-brightness-status))
+
     (set-config 'led-on (to-i in-led-on))
     (set-config 'led-highbeam-on (to-i in-led-highbeam-on))
     (set-config 'led-brightness (to-float in-led-brightness))
     (set-config 'led-brightness-highbeam (to-float in-led-brightness-highbeam))
     (set-config 'led-brightness-idle (to-float in-led-brightness-idle))
     (set-config 'led-brightness-status (to-float in-led-brightness-status))
-    (if (and (= (get-config 'bms-enabled) 1) (> bms-type 1) (!= bms-charge-state in-bms-charge-state) ){
+
+    (if (and (= (get-config 'bms-enabled) 1) (> bms-type 1) (!= bms-charge-state in-bms-charge-state) ) {
         (setq bms-charge-state (if (= bms-charge-state 1) 1 0))
         (setq bms-user-cmd 0x64)
-   })
+    })
 })
 
-(defun bms-trigger-factory-init (){
-    (if (and (= (get-config 'bms-enabled) 1) (> bms-type 1) (= bms-rs485-chip 1) ){
+(defun bms-trigger-factory-init () {
+    (if (and (= (get-config 'bms-enabled) 1) (> bms-type 1) (= bms-rs485-chip 1) ) {
         (setq bms-user-cmd 0x0e)
     })
 })
 
-(defun send-control (){
+(defun send-control () {
     (var config-string "control ")
-    (setq config-string (str-merge config-string (str-from-n (to-i led-on) "%d ") (str-from-n (to-i led-highbeam-on) "%d ") (str-from-n led-brightness "%.2f ") (str-from-n led-brightness-highbeam "%.2f ") (str-from-n led-brightness-idle "%.2f ") (str-from-n led-brightness-status "%.2f ") (str-from-n (to-i bms-charge-state) "%d ")))
+
+    (setq config-string (
+        str-merge
+        config-string
+        (str-from-n (to-i led-on) "%d ")
+        (str-from-n (to-i led-highbeam-on) "%d ")
+        (str-from-n led-brightness "%.2f ")
+        (str-from-n led-brightness-highbeam "%.2f ")
+        (str-from-n led-brightness-idle "%.2f ")
+        (str-from-n led-brightness-status "%.2f ")
+        (str-from-n (to-i bms-charge-state) "%d ")
+    ))
+
     (send-data config-string)
 })
 
-(defun recv-config (in-led-enabled in-bms-enabled in-pubmote-enabled in-led-on in-led-highbeam-on in-led-mode in-led-mode-idle in-led-mode-status in-led-mode-startup in-led-mode-button in-led-mode-footpad in-led-mall-grab-enabled
-                    in-led-brake-light-enabled in-led-brake-light-min-amps in-idle-timeout in-idle-timeout-shutoff in-led-brightness in-led-brightness-highbeam in-led-brightness-idle in-led-brightness-status in-led-status-pin in-led-status-num
-                    in-led-status-type in-led-status-reversed in-led-front-pin in-led-front-num in-led-front-type in-led-front-reversed in-led-front-strip-type
-                    in-led-rear-pin in-led-rear-num in-led-rear-type in-led-rear-reversed in-led-rear-strip-type in-led-button-pin in-led-button-strip-type in-led-footpad-pin in-led-footpad-num in-led-footpad-type in-led-footpad-reversed
-                    in-led-footpad-strip-type in-bms-rs485-di-pin in-bms-rs485-ro-pin in-bms-rs485-dere-pin in-bms-wakeup-pin in-bms-override-soc in-bms-rs485-chip in-led-loop-delay in-bms-loop-delay in-pubmote-loop-delay in-can-loop-delay
-                    in-led-max-blend-count in-led-startup-timeout in-led-dim-on-highbeam-ratio in-bms-type in-led-status-strip-type in-bms-charge-only in-led-fix in-led-show-battery-charging in-led-front-highbeam-pin in-led-rear-highbeam-pin in-bms-buff-size in-led-max-brightness) {
-    (if (>= led-context-id 0){
-    (let ((start-time (systime))
-        (timeout-val 100000))
-    (setq led-exit-flag t)
-    (loopwhile (and led-exit-flag
-              (< (- (systime) start-time) timeout-val))
-        (yield 10000))
+(defun recv-config (in-led-enabled in-bms-enabled in-pubmote-enabled in-led-on in-led-highbeam-on in-led-mode in-led-mode-idle in-led-mode-status
+    in-led-mode-startup in-led-mode-button in-led-mode-footpad in-led-mall-grab-enabled in-led-brake-light-enabled in-led-brake-light-min-amps
+    in-idle-timeout in-idle-timeout-shutoff in-led-brightness in-led-brightness-highbeam in-led-brightness-idle in-led-brightness-status
+    in-led-status-pin in-led-status-num in-led-status-type in-led-status-reversed in-led-front-pin in-led-front-num in-led-front-type
+    in-led-front-reversed in-led-front-strip-type in-led-rear-pin in-led-rear-num in-led-rear-type in-led-rear-reversed in-led-rear-strip-type
+    in-led-button-pin in-led-button-strip-type in-led-footpad-pin in-led-footpad-num in-led-footpad-type in-led-footpad-reversed
+    in-led-footpad-strip-type in-bms-rs485-di-pin in-bms-rs485-ro-pin in-bms-rs485-dere-pin in-bms-wakeup-pin in-bms-override-soc in-bms-rs485-chip
+    in-led-loop-delay in-bms-loop-delay in-pubmote-loop-delay in-can-loop-delay in-led-max-blend-count in-led-startup-timeout
+    in-led-dim-on-highbeam-ratio in-bms-type in-led-status-strip-type in-bms-charge-only in-led-fix in-led-show-battery-charging
+    in-led-front-highbeam-pin in-led-rear-highbeam-pin in-bms-buff-size in-led-max-brightness
+) {
+    (if (>= led-context-id 0) {
+        (let
+            ((start-time (systime)) (timeout-val 100000))
+            (setq led-exit-flag t)
 
-    ; Check if we exited due to timeout
-    (if (>= (- (systime) start-time) timeout-val)
-        (setq led-exit-flag nil)))
+            (loopwhile (and led-exit-flag (< (- (systime) start-time) timeout-val)) (yield 10000))
+
+            ; Check if exited due to timeout
+            (if (>= (- (systime) start-time) timeout-val) (setq led-exit-flag nil))
+        )
     })
 
-    (if (>= bms-context-id 0){
-    (let ((start-time (systime))
-       (timeout-val 100000))
-    (setq bms-exit-flag t)
-    (loopwhile (and bms-exit-flag
-              (< (- (systime) start-time) timeout-val))
-        (yield 10000))
+    (if (>= bms-context-id 0) {
+        (let
+            ((start-time (systime)) (timeout-val 100000))
+            (setq bms-exit-flag t)
 
-    ; Check if we exited due to timeout
-    (if (>= (- (systime) start-time) timeout-val)
-        (setq bms-exit-flag nil)))
+            (loopwhile (and bms-exit-flag (< (- (systime) start-time) timeout-val)) (yield 10000))
+
+            ; Check if exited due to timeout
+            (if (>= (- (systime) start-time) timeout-val) (setq bms-exit-flag nil))
+        )
     })
+
     (atomic {
         (set-config 'led-enabled (to-i in-led-enabled))
         (set-config 'bms-enabled (to-i in-bms-enabled))
@@ -232,9 +249,9 @@
         (set-config 'led-show-battery-charging (to-i in-led-show-battery-charging))
         (set-config 'bms-buff-size (to-i in-bms-buff-size))
         (set-config 'led-max-brightness (to-float in-led-max-brightness))
+    })
 
-   })
-   (if (= in-led-enabled 1){
+    (if (= in-led-enabled 1) {
         (if (and (> in-led-front-strip-type 0) (>= in-led-front-pin 0)) {
             (if (not-eq (first (trap (rgbled-init in-led-front-pin in-led-front-type))) 'exit-ok) {
                 (send-msg "Invalid Pin: led-front-pin")
@@ -242,6 +259,7 @@
                 (set-config 'led-front-pin (to-i in-led-front-pin))
             })
         })
+
         (if (and (> in-led-rear-strip-type 0) (>= in-led-rear-pin 0)) {
             (if (not-eq (first (trap (rgbled-init in-led-rear-pin in-led-rear-type))) 'exit-ok) {
                 (send-msg "Invalid Pin: led-rear-pin")
@@ -249,6 +267,7 @@
                 (set-config 'led-rear-pin (to-i in-led-rear-pin))
             })
         })
+
         (if (and (> in-led-status-strip-type 0) (>= in-led-status-pin 0)) {
             (if (not-eq (first (trap (rgbled-init in-led-status-pin in-led-status-type))) 'exit-ok) {
                 (send-msg "Invalid Pin: led-status-pin")
@@ -256,6 +275,7 @@
                 (set-config 'led-status-pin (to-i in-led-status-pin))
             })
         })
+
         (if (and (> in-led-button-strip-type 0) (>= in-led-button-pin 0)) {
             (if (not-eq (first (trap (rgbled-init in-led-button-pin 0))) 'exit-ok) {
                 (send-msg "Invalid Pin: led-button-pin")
@@ -263,6 +283,7 @@
                 (set-config 'led-button-pin (to-i in-led-button-pin))
             })
         })
+
         (if (and (> in-led-footpad-strip-type 0) (>= in-led-footpad-pin 0)) {
             (if (not-eq (first (trap (rgbled-init in-led-footpad-pin in-led-footpad-type))) 'exit-ok) {
                 (send-msg "Invalid Pin: led-footpad-pin")
@@ -287,14 +308,16 @@
             })
         })
     })
+
     (setq led-context-id (if (= (get-config 'led-enabled) 1) (spawn led-loop) -1))
     (setq bms-context-id (if (= (get-config 'bms-enabled) 1) (spawn bms-loop) -1))
+
     (if (= in-pubmote-enabled 1) {
         (if (= pubmote-context-id -1) (setq pubmote-context-id (spawn pubmote-loop)))
     })
 })
 
-(defun send-keys (key-list counter-list){
+(defun send-keys (key-list counter-list) {
     (print "Received key: ")
     (print key-list)
     (setq key-list (split-list key-list 4))
@@ -312,7 +335,7 @@
     (save-config)
 })
 
-(defun accept-tos(){
+(defun accept-tos() {
     (atomic {
         (set-config 'accept-tos 1)
         (write-val-eeprom 'accept-tos 1)
@@ -321,42 +344,56 @@
 })
 
 (defun set-config (name value) {
-    (let ((pair (assoc eeprom-addrs name)))
+    (let
+        ((pair (assoc eeprom-addrs name)))
+
         (if pair
             (loopforeach item eeprom-addrs {
                 (if (eq (car item) name)
-                    (setcdr item (list (car (cdr item))
+                    (setcdr item (
+                        list (car (cdr item))
                         (car (cdr (cdr item)))
                         (car (cdr (cdr (cdr item))))
-                        value))
+                        value
+                    ))
                 )
             })
+
             (setq eeprom-addrs (cons (cons name (list 0 'type 0 value)) eeprom-addrs))
         )
     )
 })
 
 (defun send-config () {
-(atomic {
-  (var config-string "settings ")
-  (loopforeach setting eeprom-addrs {
-    (let ((name (first setting))
-          (type (third setting))) {
-      (var value (read-val-eeprom name))
-      (setq config-string (str-merge config-string
-        (cond
-          ((eq type 'b) (str-from-n value "%d "))
-          ((eq type 'i) (str-from-n value "%d "))
-          ((eq type 'f) (str-from-n value "%.2f ")))))
+    (atomic {
+        (var config-string "settings ")
+
+        (loopforeach setting eeprom-addrs {
+            (let
+                ((name (first setting)) (type (third setting))) {
+                    (var value (read-val-eeprom name))
+
+                    (setq config-string
+                        (str-merge config-string
+                            (cond
+                                ((eq type 'b) (str-from-n value "%d "))
+                                ((eq type 'i) (str-from-n value "%d "))
+                                ((eq type 'f) (str-from-n value "%.2f "))
+                            )
+                        )
+                    )
+                }
+            )
+        })
+
+        (send-data config-string)
+        (send-status "Settings Read!")
     })
-  })
-  (send-data config-string)
-  (send-status "Settings Read!")
-  })
 })
 
 (defunret get-config (name) {
     (var pair (assoc eeprom-addrs name))
+
     (if pair
         (return (car (cdr (cdr (cdr pair)))))
         (return nil)
@@ -364,15 +401,16 @@
 })
 
 (defun save-config () {
-(atomic {
-    (loopforeach setting eeprom-addrs {
-        (var name (first setting))
-        (if (not-eq name 'crc) {
-            (write-val-eeprom name (get-config name))
+    (atomic {
+        (loopforeach setting eeprom-addrs {
+            (var name (first setting))
+            (if (not-eq name 'crc) {
+                (write-val-eeprom name (get-config name))
+            })
         })
-    })
-    (write-val-eeprom 'crc (config-crc))
-    (send-status "Settings Saved!")
+
+        (write-val-eeprom 'crc (config-crc))
+        (send-status "Settings Saved!")
     })
 })
 
@@ -380,13 +418,16 @@
     (var i 0)
 	(var crclen (* (- (length eeprom-addrs) 1) 4))
 	(var crcbuf (bufcreate crclen))
+
 	(loopforeach setting eeprom-addrs {
-            (var name (first setting))
-            (if (not-eq name 'crc) {
-                (bufset-i32 crcbuf (* i 4) (get-config name))
-                (setq i (+ i 1))
-            })
+        (var name (first setting))
+
+        (if (not-eq name 'crc) {
+            (bufset-i32 crcbuf (* i 4) (get-config name))
+            (setq i (+ i 1))
+        })
 	})
+
     (var crc (crc16 crcbuf))
     (free crcbuf)
     (return crc)
@@ -401,46 +442,51 @@
 })
 
 (defun restore-config () {
-(atomic {
-    (loopforeach setting eeprom-addrs {
-        (var name (first setting))
-        (var default-value (if (eq name 'ver-code) config-version (ix setting 3)))
-        (write-val-eeprom name default-value)
+    (atomic {
+        (loopforeach setting eeprom-addrs {
+            (var name (first setting))
+            (var default-value (if (eq name 'ver-code) config-version (ix setting 3)))
+            (write-val-eeprom name default-value)
+        })
+
+        (load-config)
+        (send-status "Settings Restored!")
     })
-	(load-config)
-	(send-status "Settings Restored!")
-})
 })
 
 (defun print-config ()
-    (loopforeach it eeprom-addrs
-        (print (list (first it) (read-val-eeprom (first it))))
-))
+    (loopforeach it eeprom-addrs (print (list (first it) (read-val-eeprom (first it)))))
+)
 
 (defun read-val-eeprom (name)
-    (let (
-        (addr (first (assoc eeprom-addrs name)))
-        (type (second (assoc eeprom-addrs name)))
+    (let
+        (
+            (addr (first (assoc eeprom-addrs name)))
+            (type (second (assoc eeprom-addrs name)))
+        )
+        (cond
+            ((eq type 'i) (eeprom-read-i addr))
+            ((eq type 'f) (eeprom-read-f addr))
+            ((eq type 'b) (eeprom-read-i addr))
+        )
     )
-    (cond
-        ((eq type 'i) (eeprom-read-i addr))
-        ((eq type 'f) (eeprom-read-f addr))
-        ((eq type 'b) (eeprom-read-i addr))
-)))
+)
 
 (defun write-val-eeprom (name val)
-    (let (
-        (addr (first (assoc eeprom-addrs name)))
-        (type (second (assoc eeprom-addrs name)))
+    (let 
+        (
+            (addr (first (assoc eeprom-addrs name)))
+            (type (second (assoc eeprom-addrs name)))
+        )
+        (cond
+            ((eq type 'i) (eeprom-store-i addr val))
+            ((eq type 'f) (eeprom-store-f addr val))
+            ((eq type 'b) (eeprom-store-i addr val))
+        )
     )
-    (cond
-        ((eq type 'i) (eeprom-store-i addr val))
-        ((eq type 'f) (eeprom-store-f addr val))
-        ((eq type 'b) (eeprom-store-i addr val))
-)))
+)
+
 (defun status () {
-    (setq wifi-current-channel (wifi-get-chan))
-    
     (var status-string "float-stats ")
     (setq status-string (str-merge status-string (str-from-n (if (< (secs-since can-last-activity-time) 1) 1 0) "%d ")))
     (setq status-string (str-merge status-string (str-from-n (if (< (secs-since pubmote-last-activity-time) 1) 1 0) "%d ")))
@@ -448,7 +494,7 @@
     (setq status-string (str-merge status-string (str-from-n bms-status "%d ")))
     (setq status-string (str-merge status-string (str-from-n bms-battery-type "%d ")))
     (setq status-string (str-merge status-string (str-from-n bms-battery-cycles "%d ")))
-    (setq status-string (str-merge status-string (str-from-n wifi-current-channel "%d ")))
+    (setq status-string (str-merge status-string (str-from-n (wifi-get-chan) "%d ")))
     (send-data status-string)
 })
 

--- a/float_accessories/lib/settings.lisp
+++ b/float_accessories/lib/settings.lisp
@@ -93,6 +93,7 @@
 (def pubmote-context-id -1)
 (def pubmote-exit-flag nil)
 (def pubmote-last-activity-time (systime))
+(def wifi-current-channel -1)
 (def led-context-id -1)
 (def led-exit-flag nil)
 (def led-last-activity-time (systime))
@@ -438,6 +439,8 @@
         ((eq type 'b) (eeprom-store-i addr val))
 )))
 (defun status () {
+    (setq wifi-current-channel (wifi-get-chan))
+    
     (var status-string "float-stats ")
     (setq status-string (str-merge status-string (str-from-n (if (< (secs-since can-last-activity-time) 1) 1 0) "%d ")))
     (setq status-string (str-merge status-string (str-from-n (if (< (secs-since pubmote-last-activity-time) 1) 1 0) "%d ")))
@@ -445,6 +448,7 @@
     (setq status-string (str-merge status-string (str-from-n bms-status "%d ")))
     (setq status-string (str-merge status-string (str-from-n bms-battery-type "%d ")))
     (setq status-string (str-merge status-string (str-from-n bms-battery-cycles "%d ")))
+    (setq status-string (str-merge status-string (str-from-n wifi-current-channel "%d ")))
     (send-data status-string)
 })
 

--- a/float_accessories/lib/utils.lisp
+++ b/float_accessories/lib/utils.lisp
@@ -13,10 +13,19 @@
 
 ;(reboot)
 
-(defun max (a b) (if (> a b) a b))
-(defun min (a b) (if (< a b) a b))
+(defun max (a b)
+    (if (> a b) a b)
+)
 
-(defun print-hex (data) (print (map (fn (x) (bufget-u8 data x)) (range (buflen data)))))
+(defun min (a b)
+    (if (< a b) a b)
+)
+
+(defun print-hex (data)
+    (print
+        (map (fn (x) (bufget-u8 data x)) (range (buflen data)))
+    )
+)
 
 (defun event-handler ()
     (loopwhile t
@@ -36,13 +45,16 @@
     (send-data (str-merge "status " text))
 )
 
-(defun mklist (len val) (map (fn (x) val) (range len)))
+(defun mklist (len val)
+    (map (fn (x) val) (range len))
+)
 
 (defun split-list (lst n)
-  (if (eq lst nil)
-      nil
-      (cons (take lst n)
-            (split-list (drop lst n) n))))
+    (if (eq lst nil)
+        nil
+        (cons (take lst n) (split-list (drop lst n) n))
+    )
+)
 
 (defunret pack-bytes-to-uint32 (byte-list) {
   (return (to-u32 (+ (shl (to-u32 (ix byte-list 0)) 24)

--- a/float_accessories/ui.qml
+++ b/float_accessories/ui.qml
@@ -1511,7 +1511,7 @@ Item {
                                     
                                     CheckBox {
                                         id: bmsRS485Chip
-                                        text: "RS485 Chip (Required to set charger level on encrypted bms. Else use OWIE RS485 uart hack)"
+                                        text: "RS485 Chip (Required for encrypted BMS charger level without Owie RS485 bypass)"
                                         checked: false
                                     }
                             

--- a/float_accessories/ui.qml
+++ b/float_accessories/ui.qml
@@ -531,6 +531,13 @@ ScrollView {
                     }
 
                     Text {
+                        id: wifiStatus
+                        Layout.fillWidth: true
+                        color: Utility.getAppHexColor("lightText")
+                        text: "WiFi Channel: Unknown"
+                    }
+
+                    Text {
                         id: bmsStatus
                         Layout.fillWidth: true
                         color: Utility.getAppHexColor("lightText")
@@ -2063,6 +2070,8 @@ function makeArgStr() {
                 bmsBatteryCycles.text = "Battery Cycles: " + Number(tokens[6])
                 lastStatusTime = 0  // Reset the timer when status is received
                 statusTimeout = false
+                var wifiChannel = Number(tokens[7])
+                wifiStatus.text = "WiFi Status: " + (wifiChannel ? wifiChannel : "Not Connected")
             } else if (str.startsWith("control")) {
                 var tokens = str.split(" ")
                 ledOn.checked = Number(tokens[1])

--- a/float_accessories/ui.qml
+++ b/float_accessories/ui.qml
@@ -1669,7 +1669,7 @@ TextArea {
           "<p>Now with BMS and Pubmote (beta)</p>" +
 
           "<p><b>BUILD INFO</b></p>" +
-		  "<p>Version 2.2</p>" +
+		  "<p>Version 2.5</p>" +
           "<p>Source code can be found here: <a href='https://github.com/relys/vesc_pkg'>https://github.com/relys/vesc_pkg</a></p>"
     Layout.fillWidth: true
     wrapMode: Text.WordWrap

--- a/float_accessories/ui.qml
+++ b/float_accessories/ui.qml
@@ -2161,8 +2161,8 @@ Item {
                 var wifiChannel = Number(tokens[7])
                 pubmoteStatus.text = "Pubmote Status: " + (
                     pubmoteConnected
-                        ? "Connected on WiFi Channel " + (wifiChannel ? wifiChannel : "?")
-                        : "Not Connected / WiFi Channel " + (wifiChannel ? wifiChannel : "?")
+                        ? "Connected (WiFi Channel " + (wifiChannel ? wifiChannel : "?") + ")"
+                        : "Not Connected (WiFi Channel " + (wifiChannel ? wifiChannel : "?") + ")"
                 )
                 pubmoteStatus.color = pubmoteConnected ? "green" : "red"
 

--- a/float_accessories/ui.qml
+++ b/float_accessories/ui.qml
@@ -23,8 +23,10 @@ Item {
 
     Component.onCompleted: {
         if (
-            !(VescIf.getLastFwRxParams().hw.includes("Express")
-            || VescIf.getLastFwRxParams().hw.includes("Avaspark"))
+            !(
+                VescIf.getLastFwRxParams().hw.includes("Express")
+                || VescIf.getLastFwRxParams().hw.includes("Avaspark")
+            )
             || VescIf.getLastFwRxParams().hw.includes("rESCue")
         ) {
             VescIf.emitMessageDialog("Float Accessories", "Warning: It doesn't look like this is installed on a VESC Express, Avaspark or rESCue board", false, false)


### PR DESCRIPTION
This PR resolves channel hopping issues when the VESC Express is in station mode but is unable to connect to the set WiFi network. Previously, the VESC Express would continually hop WiFi channels, preventing a connected Pubmote from maintaining a connection with the VESC Express. Now, the VESC Express will lock channels when it has connected to a Pubmote.

### Primary PR adjustments:
- Introduce channel locking, wifi mode checks, and related helper functions in pubmote.lisp
  - When in station mode and connected to a Pubmote, the WiFi channel will be locked
  - Upon disconnecting from a Pubmote, channel will be unlocked
- Add WiFi channel readout onto Pubmote Status status string
- Implement trip odometer for Pubmote usage
- Bump version text/tags to "2.5"

### Secondary PR adjustments:
- Remove old/unused commented code
- Update/refactor line indentation, spacing, import order, comments, spelling, and longer lines in
  - pubmote.lisp
  - settings.lisp
  - utils.lisp
  - ui.qml

### Items/cases remaining to test
- ~~Leaving WiFi range while connected to a Pubmote~~
- ~~Entering WiFi range while connected to a Pubmote~~
- Any oddities with the refactored code. None of the logic was changed, so this would just be a brief check.