### PR TITLE
Add handtest and connecting LED patterns

### DIFF
--- a/float_accessories/lib/can.lisp
+++ b/float_accessories/lib/can.lisp
@@ -161,7 +161,7 @@
                                 (setq state (bitwise-and state-byte 0x0F))
                                 (setq sat-t (shr state-byte 4))
                                 (var switch-state-byte (bufget-u8 data 10))
-                                (setq switch-state (bitwise-and switch-state-byte 0x0F))
+                                (setq switch-state (bitwise-and switch-state-byte 0x07))
                                 ;(var beep-reason-t (shr switch-state-byte 4))
                                 (setq handtest-mode (= (bitwise-and switch-state-byte 0x08) 0x08))
                                 (var footpad-adc1-t (/ (to-float (bufget-u8 data 11)) 50))

--- a/float_accessories/lib/led.lisp
+++ b/float_accessories/lib/led.lisp
@@ -567,7 +567,17 @@
 
 (defun update-status-leds (can-last-activity-time-sec) {
     (if (or (= state 15) handtest-mode (>= can-last-activity-time-sec 1) (< can-id 0)) {
-        (led-float-disabled led-status-color)
+        (cond 
+            (handtest-mode {
+                (setq status-pattern-index (led-handtest led-status-color switch-state 1 status-pattern-index 5))
+            })
+            ((= state 15) {
+                (led-float-disabled led-status-color)
+            })
+            ((>= can-last-activity-time-sec 1) {
+                (setq status-pattern-index (led-connecting led-status-color status-pattern-index))
+            })
+        )    
     }{
         (if (> rpm 250.0){
             (if (> sat-t 2) {
@@ -617,15 +627,15 @@
 
     (if (and (<= (secs-since 0) led-startup-timeout) (not (running-state) )) { (setq current-led-mode led-mode-startup)})
     (var blend-ratio (/ blend-count led-max-blend-count))
-        (looprange i 0 (length led-front-color) {
-            (setix led-front-color i (color-mix (ix prev-led-front-color i) (ix target-led-front-color i)  blend-ratio))
-        })
-        (looprange i 0 (length led-rear-color) {
-            (setix led-rear-color i (color-mix (ix prev-led-rear-color i) (ix target-led-rear-color i)  blend-ratio))
-        })
-        (looprange i 0 (length led-footpad-color) {
-            (setix led-footpad-color i (color-mix (ix prev-led-footpad-color i) (ix target-led-footpad-color i)  blend-ratio))
-        })
+    (looprange i 0 (length led-front-color) {
+        (setix led-front-color i (color-mix (ix prev-led-front-color i) (ix target-led-front-color i)  blend-ratio))
+    })
+    (looprange i 0 (length led-rear-color) {
+        (setix led-rear-color i (color-mix (ix prev-led-rear-color i) (ix target-led-rear-color i)  blend-ratio))
+    })
+    (looprange i 0 (length led-footpad-color) {
+        (setix led-footpad-color i (color-mix (ix prev-led-footpad-color i) (ix target-led-footpad-color i)  blend-ratio))
+    })
     (setix led-button-color 0 (color-mix (ix prev-led-button-color 0) (ix target-led-button-color 0)  blend-ratio))
     (setq blend-count (+ blend-count 1.0))
     ; Reset blend count and update colors when max count is reached
@@ -645,10 +655,14 @@
             })
             (if (and (> (length led-front-color) 0) (> (length led-rear-color) 0)){
                 (cond
-                    ((or (= state 15) handtest-mode) {
+                    ((= state 15) {
                         (clear-leds)
-                        (led-float-disabled led-status-color)
+                        (led-float-disabled led-rear-color)
                         (led-float-disabled led-front-color)
+                    })
+                    (handtest-mode {
+                        (setq front-pattern-index (led-handtest led-front-color switch-state 2 front-pattern-index (* 5 led-max-blend-count)))
+                        (setq rear-pattern-index (led-handtest led-rear-color switch-state 2 rear-pattern-index (* 5 led-max-blend-count)))
                     })
                     ((and (> last-activity-sec idle-timeout-shutoff) (< can-last-activity-time-sec 1) (!= state 5)){;make sure we dont' clear if we loose can bus
                         (clear-leds)
@@ -726,16 +740,15 @@
         (setq blend-count 1.0)  ; Reset blend count for new transition
         ; Blend colors
         (var blend-ratio (if (> blend-count 0) (/ blend-count led-max-blend-count) 0.0))
-            (looprange i 0 (length led-front-color) {
-                (setix led-front-color i (color-mix (ix prev-led-front-color i) (ix target-led-front-color i)  blend-ratio))
-            })
-            (looprange i 0 (length led-rear-color) {
-                (setix led-rear-color i (color-mix (ix prev-led-rear-color i) (ix target-led-rear-color i)  blend-ratio))
-            })
-            (looprange i 0 (length led-footpad-color) {
-                (setix led-footpad-color i (color-mix (ix prev-led-footpad-color i) (ix target-led-footpad-color i)  blend-ratio))
-            })
-
+        (looprange i 0 (length led-front-color) {
+            (setix led-front-color i (color-mix (ix prev-led-front-color i) (ix target-led-front-color i)  blend-ratio))
+        })
+        (looprange i 0 (length led-rear-color) {
+            (setix led-rear-color i (color-mix (ix prev-led-rear-color i) (ix target-led-rear-color i)  blend-ratio))
+        })
+        (looprange i 0 (length led-footpad-color) {
+            (setix led-footpad-color i (color-mix (ix prev-led-footpad-color i) (ix target-led-footpad-color i)  blend-ratio))
+        })
         (setix led-button-color 0 (color-mix (ix prev-led-button-color 0) (ix target-led-button-color 0)  blend-ratio))
     })
 })

--- a/float_accessories/lib/led_patterns.lisp
+++ b/float_accessories/lib/led_patterns.lisp
@@ -59,7 +59,7 @@
         )
     })
 
-    (mod (+ index 0.25) led-num)
+    (mod (+ index 0.25) (+ led-num 1))
 })
 
 (defun strobe-pattern (color-list strobe-index color) {

--- a/float_accessories/lib/led_patterns.lisp
+++ b/float_accessories/lib/led_patterns.lisp
@@ -21,6 +21,47 @@
     })
 })
 
+(defun led-handtest (color-list switch-state switch-led-count index step) {
+    (var led-num (length color-list))
+    (var color-status-half1 (if (or (= switch-state 1) (= switch-state 3)) 0xFF 0x00) )
+    (var color-status-half2 (if (or (= switch-state 2) (= switch-state 3)) 0xFF 0x00) )
+
+    ; Single loop for LEDs
+    (looprange i 0 led-num {
+        (cond
+            ((< i switch-led-count)
+                (setix color-list i color-status-half1)
+            )
+            ((= i switch-led-count)
+                (setix color-list i 0)
+            )
+            ( (and (> i switch-led-count) (< i (- led-num switch-led-count 1)))
+                (setix color-list i (color-make 255 index 0))
+            )
+            ((= i (- led-num switch-led-count 1))
+                (setix color-list i 0)
+            )
+            ((>= i (- led-num switch-led-count))
+                (setix color-list i color-status-half2)
+            )
+        )
+    })
+    (mod (+ index step) 255)
+})
+
+(defun led-connecting (color-list index) {
+    (var led-num (length color-list))
+
+    (looprange i 0 led-num {
+        (if (< i (- index 1))
+            (setix color-list i (color-make 255 0 0))
+            (setix color-list i 0)
+        )
+    })
+
+    (mod (+ index 0.25) led-num)
+})
+
 (defun strobe-pattern (color-list strobe-index color) {
     (set-led-strip-color color-list (if (= strobe-index 0) color 0x00000000))
     (mod (+ strobe-index 1) 2)


### PR DESCRIPTION
Adds new animations for hand test mode and awaiting connection to ReFloat package.

Small fix to retrieve only the lower 3 bits for the switch state when processing COMMAND_GET_ALLDATA CAN message