### PR TITLE
Fix access of dynamically defined led variables

### DIFF
--- a/float_accessories/lib/settings.lisp
+++ b/float_accessories/lib/settings.lisp
@@ -127,12 +127,15 @@
 (def hum-temp 0)
 
 (defun recv-control (in-led-on in-led-highbeam-on in-led-brightness in-led-brightness-highbeam in-led-brightness-idle in-led-brightness-status in-bms-charge-state) {
-    (setq led-on (to-i in-led-on))
-    (setq led-highbeam-on (to-i in-led-highbeam-on))
-    (setq led-brightness (to-float in-led-brightness))
-    (setq led-brightness-highbeam (to-float in-led-brightness-highbeam))
-    (setq led-brightness-idle (to-float in-led-brightness-idle))
-    (setq led-brightness-status (to-float in-led-brightness-status))
+    ; led variables are defined when led.lisp is loaded - skip if not loaded
+    (if (= (get-config 'led-enabled) 1) {
+        (setq led-on (to-i in-led-on))
+        (setq led-highbeam-on (to-i in-led-highbeam-on))
+        (setq led-brightness (to-float in-led-brightness))
+        (setq led-brightness-highbeam (to-float in-led-brightness-highbeam))
+        (setq led-brightness-idle (to-float in-led-brightness-idle))
+        (setq led-brightness-status (to-float in-led-brightness-status))
+    })
 
     (set-config 'led-on (to-i in-led-on))
     (set-config 'led-highbeam-on (to-i in-led-highbeam-on))


### PR DESCRIPTION
Fix crash when LED functionality is disabled by conditionally setting LED related variables as they aren't defined unless the LED lisp is loaded