### PR TITLE
Fix rear led strips not lighting up all the way

### DIFF
--- a/float_accessories/lib/led.lisp
+++ b/float_accessories/lib/led.lisp
@@ -158,22 +158,20 @@
         (pwm-start 1000 0.0 1 led-rear-highbeam-pin 10)
     })
 
-    (var front-highbeam-leds 0)
-    (var rear-highbeam-leds 0)
-    (cond
-        ((or (= led-front-strip-type 2) (= led-front-strip-type 3) (= led-front-strip-type 8) (= led-front-strip-type 9) (= led-front-strip-type 10)) {
-             (setq front-highbeam-leds (+ front-highbeam-leds 1))
-        })
-        ((or (= led-rear-strip-type 2) (= led-rear-strip-type 3) (= led-rear-strip-type 8) (= led-rear-strip-type 9) (= led-rear-strip-type 10)) {
-             (setq rear-highbeam-leds (+ rear-highbeam-leds 1))
-        })
-        ((or (= led-front-strip-type 4) (= led-front-strip-type 5) (= led-front-strip-type 6) (= led-front-strip-type 11)) {
-             (setq front-highbeam-leds (+ front-highbeam-leds 4))
-        })
-        ((or (= led-rear-strip-type 4) (= led-rear-strip-type 5) (= led-rear-strip-type 6) (= led-rear-strip-type 11)) {
-             (setq rear-highbeam-leds (+ rear-highbeam-leds 4))
-        })
-    )
+	(var front-highbeam-leds 0)
+	(var rear-highbeam-leds 0)
+	(if (or (= led-front-strip-type 2) (= led-front-strip-type 3) (= led-front-strip-type 8) (= led-front-strip-type 9) (= led-front-strip-type 10)) {
+		 (setq front-highbeam-leds (+ front-highbeam-leds 1))
+	})
+	(if (or (= led-rear-strip-type 2) (= led-rear-strip-type 3) (= led-rear-strip-type 8) (= led-rear-strip-type 9) (= led-rear-strip-type 10)) {
+		 (setq rear-highbeam-leds (+ rear-highbeam-leds 1))
+	})
+	(if (or (= led-front-strip-type 4) (= led-front-strip-type 5) (= led-front-strip-type 6) (= led-front-strip-type 11)) {
+		 (setq front-highbeam-leds (+ front-highbeam-leds 4))
+	})
+	(if (or (= led-rear-strip-type 4) (= led-rear-strip-type 5) (= led-rear-strip-type 6) (= led-rear-strip-type 11)) {
+		 (setq rear-highbeam-leds (+ rear-highbeam-leds 4))
+	})
     (if (>= led-footpad-pin 0) {
         (setq led-footpad-buffer (rgbled-buffer led-footpad-num led-footpad-type))
     })

--- a/float_accessories/lib/led.lisp
+++ b/float_accessories/lib/led.lisp
@@ -158,20 +158,20 @@
         (pwm-start 1000 0.0 1 led-rear-highbeam-pin 10)
     })
 
-	(var front-highbeam-leds 0)
-	(var rear-highbeam-leds 0)
-	(if (or (= led-front-strip-type 2) (= led-front-strip-type 3) (= led-front-strip-type 8) (= led-front-strip-type 9) (= led-front-strip-type 10)) {
-		 (setq front-highbeam-leds (+ front-highbeam-leds 1))
-	})
-	(if (or (= led-rear-strip-type 2) (= led-rear-strip-type 3) (= led-rear-strip-type 8) (= led-rear-strip-type 9) (= led-rear-strip-type 10)) {
-		 (setq rear-highbeam-leds (+ rear-highbeam-leds 1))
-	})
-	(if (or (= led-front-strip-type 4) (= led-front-strip-type 5) (= led-front-strip-type 6) (= led-front-strip-type 11)) {
-		 (setq front-highbeam-leds (+ front-highbeam-leds 4))
-	})
-	(if (or (= led-rear-strip-type 4) (= led-rear-strip-type 5) (= led-rear-strip-type 6) (= led-rear-strip-type 11)) {
-		 (setq rear-highbeam-leds (+ rear-highbeam-leds 4))
-	})
+    (var front-highbeam-leds 0)
+    (var rear-highbeam-leds 0)
+    (if (or (= led-front-strip-type 2) (= led-front-strip-type 3) (= led-front-strip-type 8) (= led-front-strip-type 9) (= led-front-strip-type 10)) {
+         (setq front-highbeam-leds (+ front-highbeam-leds 1))
+    })
+    (if (or (= led-rear-strip-type 2) (= led-rear-strip-type 3) (= led-rear-strip-type 8) (= led-rear-strip-type 9) (= led-rear-strip-type 10)) {
+         (setq rear-highbeam-leds (+ rear-highbeam-leds 1))
+    })
+    (if (or (= led-front-strip-type 4) (= led-front-strip-type 5) (= led-front-strip-type 6) (= led-front-strip-type 11)) {
+         (setq front-highbeam-leds (+ front-highbeam-leds 4))
+    })
+    (if (or (= led-rear-strip-type 4) (= led-rear-strip-type 5) (= led-rear-strip-type 6) (= led-rear-strip-type 11)) {
+         (setq rear-highbeam-leds (+ rear-highbeam-leds 4))
+    })
     (if (>= led-footpad-pin 0) {
         (setq led-footpad-buffer (rgbled-buffer led-footpad-num led-footpad-type))
     })


### PR DESCRIPTION
Fix rear led count when led strips are selected with high beams on both the front and rear led strips. Changed to nested if statements because when using cond, it is satisfied once front high beams are set, therefore not setting rear high beams. It could also be split into two cond constructs, one setting the front and one setting the rear led strips.