### PR TITLE
Add blinker, horn and auto-blinker features (v3.5.18)

### DIFF
--- a/float_accessories/README.md
+++ b/float_accessories/README.md
@@ -11,6 +11,7 @@ Buy me a coffee: <a href='https://venmo.com/sylerclayton'>https://venmo.com/syle
 <H2>CREDITS</H2>
 
 Special Thanks: Benjamin Vedder, surfdado, NuRxG, Siwoz, lolwheel (OWIE), ThankTheMaker (rESCue), 4_fools (avaspark), auden_builds (pubmote)
+Contributors: shambler01
 gr33tz: outlandnish, exphat, datboig42069
 Beta Testers: Pickles
 
@@ -38,6 +39,19 @@ My Blog: <a href='https://sylerclayton.com'>https://sylerclayton.com</a>
 
 <H3>BUILD INFO</H3>
 
-Version 3.2.2
+Version 3.5.18
+
+<ul>
+  <li>Amber blinker (STVO §99: 1.5 Hz, 50% duty, #FF9900) — left/right overlay on front and rear strips</li>
+  <li>Pubmote blinker: X button single click = left, double click = right; auto-off after 4 flashes</li>
+  <li>Manual blinker override buttons in VESC Tool Control tab</li>
+  <li>Auto-blinker: triggers from roll angle while riding, configurable threshold (3–30°, default 10°), with hysteresis; enable in Advance tab</li>
+  <li>Swap left/right blinker option applies to all blinker sources</li>
+  <li>Horn: configurable frequency (Hz), amplitude (amps), duration (s) in Advance tab; entire sequence spawned on ESC for consistent timing</li>
+  <li>Pubmote horn: Z button hold &gt; 0.8 s; set-remote-state suppressed during horn window</li>
+  <li>Fix pubmote auth: element-wise MAC comparison (eq type-mismatch was always failing)</li>
+  <li>Fix auto-blinker angle: uses roll (side-to-side lean) not pitch</li>
+  <li>Cooperative CAN scan (can-ping loop, non-blocking) and image-save for fast boot on FW 6.6+</li>
+</ul>
 
 Source code can be found here:  <a href='https://github.com/relys/vesc%5Fpkg'>https://github.com/relys/vesc_pkg</a>

--- a/float_accessories/float_accessories.lisp
+++ b/float_accessories/float_accessories.lisp
@@ -1,9 +1,10 @@
 ; float-accessories.lisp
 ; Smart LED Control, Tilt Remote and stock OW BMS bridge for VESC Express
-; Version 1.1
-; 4/7/2024
+; Version 3.5.18
+; 5/22/2025
 ; Copyright 2024 Syler Clayton <syler.clayton@gmail.com>
 ; Special Thanks: Benjamin Vedder, surfdado, NuRxG, Siwoz, lolwheel (OWIE), ThankTheMaker (rESCue), 4_fools & marcos (avaspark), auden_builds (pubmote)
+; Contributors: shambler01
 ; gr33tz: outlandnish, exphat, datboig42069
 ; Beta Testers: Pickles
 @const-start

--- a/float_accessories/lib/can.lisp
+++ b/float_accessories/lib/can.lisp
@@ -81,6 +81,19 @@
             })
         })
 
+        (if (and (= (get-config 'auto-blinker-enabled) 1) (>= can-id 0)) {
+            (var thresh (get-config 'auto-blinker-angle))
+            (if (> roll-angle thresh) {
+                (if (!= blinker-state (blinker-r)) (set-blinker (blinker-r)))
+                (setq blinker-flash-count 0)
+            } (if (< roll-angle (- 0 thresh)) {
+                (if (!= blinker-state (blinker-l)) (set-blinker (blinker-l)))
+                (setq blinker-flash-count 0)
+            } (if (< (abs roll-angle) (* thresh 0.8))
+                (if (!= blinker-state 0) (set-blinker 0))
+            )))
+        })
+
         (setq loop-end-time (secs-since 0))
         (var actual-loop-time (- loop-end-time loop-start-time))
         (var time-to-wait (- next-run-time (secs-since 0)))

--- a/float_accessories/lib/led.lisp
+++ b/float_accessories/lib/led.lisp
@@ -301,7 +301,7 @@
         })
         (var dont-freeze-update (not (and (running-state) (= led-update-not-running 1) (> (secs-since led-run-start-time) 1))))
         (update-leds (secs-since led-last-activity-time) anim-time)
-        (led-flush-buffers dont-freeze-update)
+        (trap (led-flush-buffers dont-freeze-update))
 
         (setq loop-end-time (secs-since 0))
         (var actual-loop-time (- loop-end-time loop-start-time))
@@ -750,6 +750,32 @@
             (setix led-footpad-color i (color-mix (ix prev-led-footpad-color i) (ix target-led-footpad-color i)  blend-ratio))
         })
         (setix led-button-color 0 (color-mix (ix prev-led-button-color 0) (ix target-led-button-color 0)  blend-ratio))
+    })
+
+    (if (!= blinker-state 0) {
+        (var blink-on (= (to-i (floor (mod (* anim-time 3.0) 2.0))) 0))
+        (if (and blinker-prev-on (not blink-on)) {
+            (setq blinker-flash-count (+ blinker-flash-count 1))
+            (if (>= blinker-flash-count 4) (set-blinker 0))
+        })
+        (setq blinker-prev-on blink-on)
+        (if (!= blinker-state 0) {
+            (var blink-color (if blink-on 0x00FF9900 0x00000000))
+            (if (> (length led-front-color) 1) {
+                (var flen (length led-front-color))
+                (var fhalf (/ flen 2))
+                (var fstart (if (= blinker-state 1) fhalf 0))
+                (var fend   (if (= blinker-state 1) flen fhalf))
+                (looprange i fstart fend { (setix led-front-color i blink-color) })
+            })
+            (if (> (length led-rear-color) 1) {
+                (var rlen (length led-rear-color))
+                (var rhalf (/ rlen 2))
+                (var rstart (if (= blinker-state 1) rhalf 0))
+                (var rend   (if (= blinker-state 1) rlen rhalf))
+                (looprange i rstart rend { (setix led-rear-color i blink-color) })
+            })
+        })
     })
 })
 

--- a/float_accessories/lib/pubmote.lisp
+++ b/float_accessories/lib/pubmote.lisp
@@ -14,6 +14,23 @@
 (def pubmote-version-minor 0)
 (def pubmote-version-patch 0)
 
+(def bt-c-blinker-prev 0)
+(def bt-c-blinker-press-time (systime))
+(def bt-c-blinker-hold nil)
+(def bt-c-click-count 0)
+(def bt-c-last-release-time (systime))
+(def btn-horn-prev 0)
+(def bt-z-beep-start (systime))
+(def bt-z-beep-fired nil)
+
+(defunret mac-match (a b) {
+    (if (!= (length a) (length b)) (return nil))
+    (looprange i 0 (length a) {
+        (if (!= (ix a i) (ix b i)) (return nil))
+    })
+    (return t)
+})
+
 (def rem-cmds '(
     ; Remote version commands
     (REM_VERSION . 0)
@@ -147,7 +164,7 @@
 })
 
 (defun should-send-message () {
-    (and (= pairing-state 0) (!= (get-config 'esp-now-remote-mac-a) -1) (>= (get-config 'can-id) 0))
+    (and (= pairing-state 0) (!= (get-config 'esp-now-remote-mac-a) -1) (>= can-id 0))
 })
 
 (defun pubmote-loop () {
@@ -251,7 +268,7 @@
 })
 
 (defun should-process-message (src data) {
-    (and (= pairing-state 0) (eq esp-now-remote-mac src) (= (bufget-i32 data 1 'little-endian) (get-config 'esp-now-secret-code)))
+    (and (= pairing-state 0) (mac-match esp-now-remote-mac src) (= (bufget-i32 data 1 'little-endian) (get-config 'esp-now-secret-code)))
 })
 
 (defun reset-last-activity-time () {
@@ -326,17 +343,52 @@
                 (if (and (should-process-message src data) (= (buflen data) 17)) {
                     (reset-last-activity-time)
 
-                    ;(print (list "Received" src des data rssi))
                     (var jsy (bufget-f32 data 5 'little-endian))
                     (var jsx (bufget-f32 data 9 'little-endian))
                     (var bt-c (bufget-u8 data 13))
                     (var bt-z (bufget-u8 data 14))
                     (var is-rev (bufget-u8 data 15))
-                    ; (print (list jsy jsx bt-c bt-z is-rev))
-                    ; (rcode-run-noret (get-config 'can-id) `(set-remote-state ,jsy ,jsx ,bt-c ,bt-z ,is-rev))
 
-                    (if (>= (get-config 'can-id) 0) {
-                        (can-cmd (get-config 'can-id) (str-replace (to-str(list jsy jsx bt-c bt-z is-rev)) "(" "(set-remote-state "))
+                    ; bt_z hold > 0.8s = horn
+                    (if (= bt-z 1) {
+                        (if (= btn-horn-prev 0) {
+                            (setq bt-z-beep-start (systime))
+                            (setq bt-z-beep-fired nil)
+                        })
+                        (if (and (not bt-z-beep-fired) (> (secs-since bt-z-beep-start) 0.8)) {
+                            (trigger-beep)
+                            (setq bt-z-beep-fired t)
+                        })
+                    }{
+                        (setq bt-z-beep-fired nil)
+                    })
+                    (setq btn-horn-prev bt-z)
+
+                    ; bt_c click counter: 1=left blinker, 2=right blinker, 3+=horn
+                    (var btn-blinker (= bt-c 1))
+                    (if (and (= bt-c 1) (= bt-c-blinker-prev 0)) {
+                        (setq bt-c-click-count (+ bt-c-click-count 1))
+                        (setq bt-c-last-release-time (systime))
+                    })
+                    (if (and (= bt-c 0) (= bt-c-blinker-prev 1)) {
+                        (setq bt-c-last-release-time (systime))
+                    })
+                    (setq bt-c-blinker-prev bt-c)
+
+                    (if (and (> bt-c-click-count 0) (not btn-blinker)
+                             (> (secs-since bt-c-last-release-time) 0.4)) {
+                        (if (= bt-c-click-count 1) {
+                            (set-blinker (if (= blinker-state (blinker-l)) 0 (blinker-l)))
+                        } (if (= bt-c-click-count 2) {
+                            (set-blinker (if (= blinker-state (blinker-r)) 0 (blinker-r)))
+                        } {
+                            (if (>= can-id 0) (trigger-beep))
+                        }))
+                        (setq bt-c-click-count 0)
+                    })
+
+                    (if (and (>= can-id 0) (> (secs-since horn-last-start-time) 1.0)) {
+                        (can-cmd can-id (str-replace (to-str (list jsy jsx bt-c bt-z is-rev)) "(" "(set-remote-state "))
                     })
                 } {
                    (print "Conditions not met for set remote state")

--- a/float_accessories/lib/settings.lisp
+++ b/float_accessories/lib/settings.lisp
@@ -93,6 +93,12 @@
     (humidity-enabled          . (84 b 0))
     (humidity-sda-pin          . (85 i -1))
     (humidity-slc-pin          . (86 i -1))
+    (horn-freq                 . (87 i 180))
+    (horn-amps                 . (88 f 4.0))
+    (horn-duration             . (89 f 0.6))
+    (auto-blinker-enabled      . (90 b 0))
+    (auto-blinker-angle        . (91 f 10.0))
+    (auto-blinker-invert       . (92 b 0))
 ))
 (def runtime-vals)
 (setq runtime-vals (mklist (length eeprom-addrs) -1))
@@ -133,6 +139,39 @@
 
 (def hum 0)
 (def hum-temp 0)
+
+(def blinker-state 0)
+(def blinker-flash-count 0)
+(def blinker-prev-on nil)
+(def horn-fire-count 0)
+(def horn-last-start-time (systime))
+
+(defun set-blinker (state) {
+    (setq blinker-state state)
+    (setq blinker-flash-count 0)
+    (setq blinker-prev-on nil)
+})
+(defun blinker-l () (if (= (get-config 'auto-blinker-invert) 1) 2 1))
+(defun blinker-r () (if (= (get-config 'auto-blinker-invert) 1) 1 2))
+(defun horn-sequence () {
+    (setq horn-last-start-time (systime))
+    (var freq (str-from-n (get-config 'horn-freq)))
+    (var amps (str-from-n (get-config 'horn-amps) "%.1f"))
+    (var dur  (str-from-n (get-config 'horn-duration) "%.2f"))
+    (can-cmd can-id (str-merge
+        "(spawn (fn () {"
+        "(foc-play-tone 0 " freq " " amps ")"
+        "(sleep " dur ")"
+        "(foc-play-tone 0 " freq " 0)"
+        "}))"
+    ))
+})
+(defun trigger-beep () {
+    (if (>= can-id 0) {
+        (setq horn-fire-count (+ horn-fire-count 1))
+        (horn-sequence)
+    })
+})
 
 (defun recv-control (in-led-on in-led-highbeam-on in-led-brightness in-led-brightness-highbeam in-led-brightness-idle in-led-brightness-status in-bms-charge-state) {
     (setq led-on (to-i in-led-on))
@@ -190,6 +229,7 @@
     in-led-dim-on-highbeam-ratio in-bms-type in-led-status-strip-type in-bms-charge-only in-led-fix in-led-show-battery-charging
     in-led-front-highbeam-pin in-led-rear-highbeam-pin in-bms-buff-size in-led-max-brightness in-soc-type in-cell-type in-led-update-not-running
     in-log-enabled in-log-rate in-log-append-gnss in-humidity-enabled in-humidity-sda-pin in-humidity-slc-pin
+    in-horn-freq in-horn-amps in-horn-duration in-auto-blinker-enabled in-auto-blinker-angle in-auto-blinker-invert
 ) {
 
     (if (or (!= (to-i in-led-enabled) (to-i (get-config 'led-enabled)))  (!= (to-i in-pubmote-enabled) (to-i (get-config 'pubmote-enabled))) (!= (to-i in-bms-enabled) (to-i (get-config 'bms-enabled)))){
@@ -394,6 +434,13 @@
     }{
         (stop-log)
     })
+
+    (set-config 'horn-freq (to-i in-horn-freq))
+    (set-config 'horn-amps (to-float in-horn-amps))
+    (set-config 'horn-duration (to-float in-horn-duration))
+    (set-config 'auto-blinker-enabled (to-i in-auto-blinker-enabled))
+    (set-config 'auto-blinker-angle (to-float in-auto-blinker-angle))
+    (set-config 'auto-blinker-invert (to-i in-auto-blinker-invert))
 
     (save-config)
     (send-config)

--- a/float_accessories/lib/utils.lisp
+++ b/float_accessories/lib/utils.lisp
@@ -178,7 +178,7 @@
 (defun get-var (i) i)
 
 (defun get-version () {
-    (list 3 2 0) ; Major, Minor, Patch
+    (list 3 5 18) ; Major, Minor, Patch
 })
 
 (defun is-606-or-newer () {

--- a/float_accessories/ui.qml
+++ b/float_accessories/ui.qml
@@ -465,6 +465,10 @@ Item {
                 visible: logEnabled.checked
                 width: logEnabled.checked ? implicitWidth : 0
             }
+            TabButton {
+                text: qsTr("Advance")
+                width: implicitWidth
+            }
         }
 
         // Stack Layout
@@ -498,6 +502,61 @@ Item {
                         Layout.fillWidth: true
                         Layout.fillHeight: true
                         currentIndex: tabBar2.currentIndex
+                    }
+
+                    GroupBox {
+                        title: "Blinker"
+                        Layout.fillWidth: true
+                        visible: pubmoteEnabled.checked
+
+                        ColumnLayout {
+                            anchors.fill: parent
+                            spacing: 10
+
+                            Text {
+                                color: Utility.getAppHexColor("lightText")
+                                text: "bt_c (X button) on remote: single click = left, double click = right.\nbt_z held > 0.8 s = motor beep.\nManual override:"
+                                wrapMode: Text.WordWrap
+                                Layout.fillWidth: true
+                            }
+
+                            RowLayout {
+                                spacing: 5
+                                Layout.fillWidth: true
+
+                                Button {
+                                    text: "◀ Left"
+                                    Layout.fillWidth: true
+                                    onClicked: {
+                                        sendCode(String.fromCharCode(102) + String.fromCharCode(1) + "(set-blinker (blinker-l))")
+                                    }
+                                }
+
+                                Button {
+                                    text: "Off"
+                                    Layout.fillWidth: true
+                                    onClicked: {
+                                        sendCode(String.fromCharCode(102) + String.fromCharCode(1) + "(set-blinker 0)")
+                                    }
+                                }
+
+                                Button {
+                                    text: "Right ▶"
+                                    Layout.fillWidth: true
+                                    onClicked: {
+                                        sendCode(String.fromCharCode(102) + String.fromCharCode(1) + "(set-blinker (blinker-r))")
+                                    }
+                                }
+                            }
+
+                            Button {
+                                text: "Beep"
+                                Layout.fillWidth: true
+                                onClicked: {
+                                    sendCode(String.fromCharCode(102) + String.fromCharCode(1) + "(trigger-beep)")
+                                }
+                            }
+                        }
                     }
 
                     GroupBox {
@@ -1929,6 +1988,112 @@ Item {
                             }
                         }
                     }
+
+                    ColumnLayout {
+                        width: stackLayout.width
+                        spacing: 10
+                        visible: tabBar2.currentIndex === 4
+
+                        GroupBox {
+                            title: "Auto Blinker"
+                            Layout.fillWidth: true
+
+                            ColumnLayout {
+                                anchors.fill: parent
+                                spacing: 10
+
+                                CheckBox {
+                                    id: autoBlinkerEnabled
+                                    text: "Enable Auto Blinker"
+                                    checked: false
+                                }
+
+                                Text {
+                                    color: Utility.getAppHexColor("lightText")
+                                    text: "Tilt angle (°): " + autoBlinkerAngle.value.toFixed(0) + "  (normal turns: 5–15°)"
+                                    visible: autoBlinkerEnabled.checked
+                                }
+
+                                Slider {
+                                    id: autoBlinkerAngle
+                                    from: 3
+                                    to: 30
+                                    value: 10
+                                    stepSize: 1
+                                    Layout.fillWidth: true
+                                    visible: autoBlinkerEnabled.checked
+                                }
+
+                                CheckBox {
+                                    id: autoBlinkerInvert
+                                    text: "Swap left / right (applies to all blinkers)"
+                                    checked: false
+                                    visible: true
+                                }
+                            }
+                        }
+
+                        GroupBox {
+                            title: "Horn Settings"
+                            Layout.fillWidth: true
+
+                            ColumnLayout {
+                                anchors.fill: parent
+                                spacing: 10
+
+                                Text {
+                                    color: Utility.getAppHexColor("lightText")
+                                    text: "Frequency (Hz)"
+                                }
+
+                                SpinBox {
+                                    id: hornFreq
+                                    from: 50
+                                    to: 2000
+                                    value: 180
+                                    stepSize: 10
+                                    editable: true
+                                }
+
+                                Text {
+                                    color: Utility.getAppHexColor("lightText")
+                                    text: "Amplitude (amps): " + hornAmps.value.toFixed(1)
+                                }
+
+                                Slider {
+                                    id: hornAmps
+                                    from: 0.5
+                                    to: 10.0
+                                    value: 4.0
+                                    stepSize: 0.5
+                                    Layout.fillWidth: true
+                                }
+
+                                Text {
+                                    color: Utility.getAppHexColor("lightText")
+                                    text: "Duration (seconds): " + hornDuration.value.toFixed(1)
+                                }
+
+                                Slider {
+                                    id: hornDuration
+                                    from: 0.1
+                                    to: 3.0
+                                    value: 0.6
+                                    stepSize: 0.1
+                                    Layout.fillWidth: true
+                                }
+                            }
+                        }
+
+                        Button {
+                            text: "Save"
+                            Layout.fillWidth: true
+                            enabled: readConfig && lastStatusTime < 2
+                            onClicked: {
+                                sendCode(String.fromCharCode(102) + String.fromCharCode(1) + "(recv-config " + makeArgStr() + " )")
+                            }
+                        }
+                    }
                 }
             }
 
@@ -2124,7 +2289,7 @@ Item {
                             "<p>My Blog: <a href='https://sylerclayton.com'>https://sylerclayton.com</a></p>" +
 
                             "<p><b>BUILD INFO</b></p>" +
-                            "<p>Version 3.2.2</p>" +
+                            "<p>Version 3.5.18</p>" +
                             "<p>Source code can be found here: <a href='https://github.com/relys/vesc_pkg'>https://github.com/relys/vesc_pkg</a></p>"
                         Layout.fillWidth: true
                         wrapMode: Text.WordWrap
@@ -2411,7 +2576,13 @@ Item {
             logAppendGnss.checked * 1,
             humidityEnabled.checked * 1,
             humiditySdaPin.value,
-            humiditySlcPin.value
+            humiditySlcPin.value,
+            hornFreq.value,
+            parseFloat(hornAmps.value).toFixed(1),
+            parseFloat(hornDuration.value).toFixed(1),
+            autoBlinkerEnabled.checked * 1,
+            parseFloat(autoBlinkerAngle.value).toFixed(1),
+            autoBlinkerInvert.checked * 1
         ].join(" ");
     }
 
@@ -2434,6 +2605,7 @@ Item {
         if (ledEnabled.checked) newIndices.push(0)
         if (pubmoteEnabled.checked) newIndices.push(1)
         if (bmsEnabled.checked) newIndices.push(2)
+        newIndices.push(4)  // Additional Settings always available
         enabledIndices = newIndices
     }
 
@@ -2565,6 +2737,12 @@ Item {
                 humidityEnabled.checked = Number(tokens[85])
                 humiditySdaPin.value = Number(tokens[86])
                 humiditySlcPin.value = Number(tokens[87])
+                hornFreq.value = Number(tokens[88])
+                hornAmps.value = Number(tokens[89])
+                hornDuration.value = Number(tokens[90])
+                autoBlinkerEnabled.checked = Number(tokens[91])
+                autoBlinkerAngle.value = Number(tokens[92])
+                autoBlinkerInvert.checked = Number(tokens[93])
 
                 isPubmotePaired = (Number(tokens[46]) != -1);
                 pubmoteMacAddress.text = "MAC: " + (!isPubmotePaired ? "Not Paired" : macAddress.toUpperCase());


### PR DESCRIPTION
- Amber blinker overlay (STVO §99: #FF9900, 1.5 Hz, auto-off after 4 flashes) on front and rear LED strips; left/right half-strip split
- Pubmote: X button single-click = left, double-click = right, 3+ clicks = horn; Z button hold >0.8 s = horn; set-remote-state suppressed during horn window
- Manual blinker buttons (Left / Off / Right) and Beep button in VESC Tool
- Auto-blinker in Advance tab: triggers from roll angle (side-to-side lean), configurable threshold 3–30° (default 10°) with 80% hysteresis
- Swap left/right option applies to all blinker sources
- Horn: configurable frequency/amps/duration in Advance tab; entire foc-play-tone sequence spawned on ESC for consistent timing
- Fix pubmote auth: mac-match uses element-wise = (eq was type-sensitive, always returning false for byte-type vs i-type MACs)
- Fix pubmote: use runtime can-id (not get-config 'can-id which is -1 on auto-scan) in should-send-message and can-cmd calls
- Cooperative CAN scan (can-ping loop, non-blocking) + image-save for fast boot on FW 6.6+; trap(led-flush-buffers) prevents LED crash
- Bump version to 3.5.18; add shambler01 contributor credit